### PR TITLE
ivy: add opmap keyword

### DIFF
--- a/exec/context.go
+++ b/exec/context.go
@@ -152,6 +152,16 @@ func (c *Context) EvalUnary(op string, right value.Value) value.Value {
 	return fn.EvalUnary(c, right)
 }
 
+// UserDefinedMap evalutes a user-defined operator on each element of the right operand.
+func (c *Context) UserDefinedMap(op string, right value.Value) value.Value {
+	fn := c.Unary(op)
+	if fn == nil {
+		value.Errorf("unary %q not implemented", op)
+	}
+
+	return value.EvalUserDefinedMap(c, op, right)
+}
+
 func (c *Context) Unary(op string) value.UnaryOp {
 	userFn := c.UnaryFn[op]
 	if userFn != nil {

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -41,6 +41,7 @@ const (
 	Operator   // known operator
 	Op         // "op", operator definition keyword
 	OpDelete   // "opdelete", operator undefinition keyword
+	OpMap      // "opmap", operator map-function keyword
 	Rational   // rational number like 2/3
 	Complex    // complex number like 3j2
 	RightBrack // ']'
@@ -342,6 +343,8 @@ func lexIdentifier(l *Scanner) stateFn {
 		return l.emit(Op)
 	case word == "opdelete":
 		return l.emit(OpDelete)
+	case word == "opmap":
+		return l.emit(OpMap)
 	case word == "o" && l.peek() == '.':
 		return lexOperator
 	case l.defined(word):

--- a/scan/type_string.go
+++ b/scan/type_string.go
@@ -20,18 +20,19 @@ func _() {
 	_ = x[Operator-9]
 	_ = x[Op-10]
 	_ = x[OpDelete-11]
-	_ = x[Rational-12]
-	_ = x[Complex-13]
-	_ = x[RightBrack-14]
-	_ = x[RightParen-15]
-	_ = x[Semicolon-16]
-	_ = x[String-17]
-	_ = x[Colon-18]
+	_ = x[OpMap-12]
+	_ = x[Rational-13]
+	_ = x[Complex-14]
+	_ = x[RightBrack-15]
+	_ = x[RightParen-16]
+	_ = x[Semicolon-17]
+	_ = x[String-18]
+	_ = x[Colon-19]
 }
 
-const _Type_name = "EOFErrorNewlineAssignCharIdentifierLeftBrackLeftParenNumberOperatorOpOpDeleteRationalComplexRightBrackRightParenSemicolonStringColon"
+const _Type_name = "EOFErrorNewlineAssignCharIdentifierLeftBrackLeftParenNumberOperatorOpOpDeleteOpMapRationalComplexRightBrackRightParenSemicolonStringColon"
 
-var _Type_index = [...]uint8{0, 3, 8, 15, 21, 25, 35, 44, 53, 59, 67, 69, 77, 85, 92, 102, 112, 121, 127, 132}
+var _Type_index = [...]uint8{0, 3, 8, 15, 21, 25, 35, 44, 53, 59, 67, 69, 77, 82, 90, 97, 107, 117, 126, 132, 137}
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_Type_index)-1) {

--- a/testdata/opmap.ivy
+++ b/testdata/opmap.ivy
@@ -1,0 +1,24 @@
+
+# One input value returning a vector.
+op double N = N * 2
+input = 4
+output = opmap double input
+output
+
+	8
+
+# One input value returning a vector.
+op mulunder20 M = ((T mod M) == 0) sel T = -1 drop iota 20
+input = 4
+output = opmap mulunder20 input
+output
+
+	4 8 12 16
+
+# Vector input returning a vector of vectors.
+op mulunder20 M = ((T mod M) == 0) sel T = -1 drop iota 20
+input = 3 5
+output = opmap mulunder20 input
+output
+
+	(3 6 9 12 15 18) (5 10 15)

--- a/value/context.go
+++ b/value/context.go
@@ -73,4 +73,7 @@ type Context interface {
 
 	// UserDefined reports whether the specified op is user-defined.
 	UserDefined(op string, isBinary bool) bool
+
+	// UserDefinedMap evalutes a user-defined operator on each element of the right operand.
+	UserDefinedMap(op string, right Value) Value
 }

--- a/value/vector.go
+++ b/value/vector.go
@@ -51,6 +51,10 @@ func (v Vector) ProgString() string {
 	panic("vector.ProgString - cannot happen")
 }
 
+func (v *Vector) Append(val Value) {
+	*v = append(*v, val)
+}
+
 // Constants to make it easier to read calls to the printing routines.
 const (
 	withParens        = true
@@ -85,10 +89,12 @@ func (v Vector) oneLineSprint(conf *config.Config, parens, spaces bool) (string,
 // multiLineSprint formats a vector that may span multiple lines,
 // returning the result as a slice of strings, one per line.
 // Lots of flags:
+//
 //	allScalars: the vector is all scalar values and can be printed without parens.
 //	allChars: the vector is all chars and can be printed extra simply.
 //	spaces: put spaces between elements.
 //	trim: remove trailing spaces from each line.
+//
 // If trim is not set, the lines are all of equal length, bytewise.
 //
 // The return values are the printed lines and, along the other axis,


### PR DESCRIPTION
PR for discussion.

This `opmap` keyword:
- currently only works with unary user-defined operations, not binary.  Could workaround by writing a second user-defined operation and putting both arguments into one vector as input.
- uses a pre-fix notation opmap fn array which is maybe not fitting with the language.  

Examples in the test file [opmap.ivy](https://github.com/superfrink/ivy/blob/opmap/testdata/opmap.ivy)